### PR TITLE
fix NASA client env fallback

### DIFF
--- a/lib/handlers.go
+++ b/lib/handlers.go
@@ -116,13 +116,13 @@ func HandleLaunchesSummary(client SpaceXClientInterface) http.HandlerFunc {
 func HandleRoot() http.HandlerFunc {
 	return LoggingMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		endpoints := map[string]string{
-			"/":                      "Shows this list of available endpoints",
-			"/api/latest-launch":     "Get the latest SpaceX launch",
-			"/api/rocket":            "Get a specific rocket by ID (use ?id=[rocket_id])",
-			"/api/rockets":           "Get a list of all SpaceX rockets",
-			"/api/numbers":           "Get a random math fact",
-			"/api/nasa":              "Get NASA's Astronomy Picture of the Day",
-			"/api/launches-summary":   "Get summary of launches by year and ship over the last 3 years",
+			"/":                     "Shows this list of available endpoints",
+			"/api/latest-launch":    "Get the latest SpaceX launch",
+			"/api/rocket":           "Get a specific rocket by ID (use ?id=[rocket_id])",
+			"/api/rockets":          "Get a list of all SpaceX rockets",
+			"/api/numbers":          "Get a random math fact",
+			"/api/nasa":             "Get NASA's Astronomy Picture of the Day",
+			"/api/launches-summary": "Get summary of launches by year and ship over the last 3 years",
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/lib/nasa.go
+++ b/lib/nasa.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -18,22 +19,27 @@ type NASAClient struct {
 
 // Response structures for NASA API
 type APOD struct {
-	Title       string `json:"title"`
-	Date        string `json:"date"`
-	Explanation string `json:"explanation"`
-	URL         string `json:"url"`
-	MediaType   string `json:"media_type"`
+	Title          string `json:"title"`
+	Date           string `json:"date"`
+	Explanation    string `json:"explanation"`
+	URL            string `json:"url"`
+	MediaType      string `json:"media_type"`
 	ServiceVersion string `json:"service_version"`
 }
 
-// NewNASAClient creates a new NASA API client
+// NewNASAClient creates a new NASA API client.
+// Uses NASA_API_KEY env if set; otherwise falls back to DEMO_KEY (strict rate limits).
 func NewNASAClient() *NASAClient {
+	apiKey := os.Getenv("NASA_API_KEY")
+	if apiKey == "" {
+		apiKey = "DEMO_KEY"
+	}
 	return &NASAClient{
 		baseURL: "https://api.nasa.gov",
 		httpClient: &http.Client{
 			Timeout: time.Second * 10,
 		},
-		apiKey: "DEMO_KEY", // Using demo key for simplicity
+		apiKey: apiKey,
 	}
 }
 
@@ -93,12 +99,12 @@ func (c *NASAClient) GetAPOD() (*APOD, error) {
 			return nil, fmt.Errorf("NASA API rate limit exceeded")
 		}
 	}
-	
+
 	// Also check for 429 status code (Too Many Requests)
 	if resp.StatusCode == http.StatusTooManyRequests {
 		return nil, fmt.Errorf("NASA API rate limit exceeded (429)")
 	}
-	
+
 	// Check for other non-success status codes
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("NASA API error: HTTP %d", resp.StatusCode)


### PR DESCRIPTION
## Summary
- Read `NASA_API_KEY` when present and fall back to `DEMO_KEY` otherwise.
- Clean up the related handler imports and formatting.

## Validation
- `go test ./...`