### PR TITLE
feat: add Speedscale+Istio overlay

### DIFF
--- a/overlays/speedscale/external-services.yaml
+++ b/overlays/speedscale/external-services.yaml
@@ -1,0 +1,46 @@
+# ServiceEntries required for REGISTRY_ONLY Istio egress policy.
+# Covers all external APIs called by outerspace-server.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-spacexdata
+  namespace: outerspace
+spec:
+  hosts:
+  - api.spacexdata.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  location: MESH_EXTERNAL
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-nasa
+  namespace: outerspace
+spec:
+  hosts:
+  - api.nasa.gov
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  location: MESH_EXTERNAL
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-numbersapi
+  namespace: outerspace
+spec:
+  hosts:
+  - numbersapi.com
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  location: MESH_EXTERNAL
+  resolution: DNS

--- a/overlays/speedscale/inject-server.yaml
+++ b/overlays/speedscale/inject-server.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: outerspace-server
+  annotations:
+    capture.speedscale.com/enabled: "true"

--- a/overlays/speedscale/kustomization.yaml
+++ b/overlays/speedscale/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: outerspace
+
+resources:
+- ../../k8s
+- ns.yaml
+- external-services.yaml
+
+patches:
+- path: inject-server.yaml
+# Disable Speedscale sidecar webhook on all Deployments to avoid conflicts
+# with Istio's sidecar injector. Capture runs via eBPF (inject-server.yaml).
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: irrelevant
+      annotations:
+        sidecar.speedscale.com/inject: "false"

--- a/overlays/speedscale/ns.yaml
+++ b/overlays/speedscale/ns.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: outerspace
+  labels:
+    istio-injection: enabled
+    speedscale: "true"


### PR DESCRIPTION
# Problem
No Speedscale capture or Istio integration for the outerspace-go demo when deployed to staging-decoy.

# Solution
Adds `overlays/speedscale/` with:
- `ns.yaml` — `outerspace` namespace with `istio-injection: enabled` and `speedscale: true` labels
- `inject-server.yaml` — enables eBPF capture (`capture.speedscale.com/enabled: true`) on `outerspace-server`
- `external-services.yaml` — Istio `ServiceEntry` resources for the three external APIs called by the server: `api.spacexdata.com`, `api.nasa.gov`, `numbersapi.com` (required under `REGISTRY_ONLY` egress policy)
- `kustomization.yaml` — wires everything together; globally disables Speedscale sidecar webhook to avoid admission conflicts with Istio

ArgoCD Application CR in `speedscale/demo` points at this overlay path.

## Checklist
- [x] `kubectl kustomize overlays/speedscale` builds clean
- [x] ServiceEntries cover all external hosts from `lib/` clients
- [x] Client deployment excluded from capture (load generator only)